### PR TITLE
fix: ExternalUserIdResolver를 WebConfig의 Resolver로 추가 / #26

### DIFF
--- a/src/main/java/org/creditto/creditto_service/global/config/WebConfig.java
+++ b/src/main/java/org/creditto/creditto_service/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package org.creditto.creditto_service.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.creditto.creditto_service.global.resolver.ExternalUserIdResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final ExternalUserIdResolver externalUserIdResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(externalUserIdResolver);
+    }
+}


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #26

## ✅ 작업 내용

- ExternalUserIdResolver를 WebConfig의 Resolver로 추가

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
