### PR TITLE
feat: OpenFeign 관련 예외 발생 처리 / #40

### DIFF
--- a/src/main/java/org/creditto/creditto_service/global/common/Constants.java
+++ b/src/main/java/org/creditto/creditto_service/global/common/Constants.java
@@ -8,4 +8,6 @@ public final class Constants {
 
     public static final String USER_ID = "user_id";
     public static final String USER_NAME = "userName";
+    public static final String CODE = "code";
+    public static final String MESSAGE = "message";
 }

--- a/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignClient.java
+++ b/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignClient.java
@@ -15,7 +15,8 @@ import java.util.List;
 
 @FeignClient(
         name = "core-banking",
-        url = "${CORE_BANKING_SERVER_URL}"
+        url = "${CORE_BANKING_SERVER_URL}",
+        configuration = CoreBankingFeignConfig.class
 )
 public interface CoreBankingFeignClient {
     @PostMapping(value = "/api/core/account/{userId}", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignConfig.java
+++ b/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignConfig.java
@@ -1,0 +1,15 @@
+package org.creditto.creditto_service.global.infra.corebanking;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CoreBankingFeignConfig {
+
+    @Bean
+    public ErrorDecoder coreBankingFeignErrorDecoder(ObjectMapper objectMapper) {
+        return new CoreBankingFeignErrorDecoder(objectMapper);
+    }
+}

--- a/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignErrorDecoder.java
+++ b/src/main/java/org/creditto/creditto_service/global/infra/corebanking/CoreBankingFeignErrorDecoder.java
@@ -1,0 +1,73 @@
+package org.creditto.creditto_service.global.infra.corebanking;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.creditto.creditto_service.global.response.error.ErrorMessage;
+import org.creditto.creditto_service.global.response.exception.CoreBankingFeignException;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.creditto.creditto_service.global.common.Constants.CODE;
+import static org.creditto.creditto_service.global.common.Constants.MESSAGE;
+
+/**
+ * CoreBanking OpenFeign 오류 응답을 Creditto 예외로 변환하는 디코더.
+ * CoreBanking의 상태 코드와 메시지를 그대로 {@link CoreBankingFeignException}으로 전달한다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CoreBankingFeignErrorDecoder implements ErrorDecoder {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        int httpStatus = response != null
+                ? response.status()
+                : HttpStatus.INTERNAL_SERVER_ERROR.value();
+
+        String responseBody = readResponseBody(response);
+        log.warn("[CoreBankingFeignErrorDecoder] CoreBanking OpenFeign 에러 / methodKey={}, status={}, body={}", methodKey, httpStatus, responseBody);
+
+        if (!StringUtils.hasText(responseBody)) {
+            return new CoreBankingFeignException(httpStatus, null, ErrorMessage.SERVER_ERROR);
+        }
+
+        try {
+            JsonNode node = objectMapper.readTree(responseBody);
+            Integer code = node.hasNonNull(CODE)
+                    ? node.get(CODE).asInt()
+                    : null;
+
+            String message = node.hasNonNull(MESSAGE)
+                    ? node.get(MESSAGE).asText()
+                    : ErrorMessage.SERVER_ERROR;
+
+            return new CoreBankingFeignException(httpStatus, code, message);
+        } catch (IOException e) {
+            log.error("[CoreBankingFeignErrorDecoder] Response Body 파싱 에러", e);
+            return new CoreBankingFeignException(httpStatus, null, ErrorMessage.SERVER_ERROR);
+        }
+    }
+
+    private String readResponseBody(Response response) {
+        if (response == null || response.body() == null) {
+            return null;
+        }
+
+        try (InputStream inputStream = response.body().asInputStream()) {
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            log.error("[CoreBankingFeignErrorDecoder] Response Body 파싱 에러", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/creditto/creditto_service/global/response/error/ErrorMessage.java
+++ b/src/main/java/org/creditto/creditto_service/global/response/error/ErrorMessage.java
@@ -23,4 +23,6 @@ public final class ErrorMessage {
      * DENIED - 접근 거부
      */
     public static final String ACCESS_DENIED = "권한이 없습니다.";
+
+    public static final String SERVER_ERROR = "서버 내부 오류 입니다.";
 }

--- a/src/main/java/org/creditto/creditto_service/global/response/exception/CoreBankingFeignException.java
+++ b/src/main/java/org/creditto/creditto_service/global/response/exception/CoreBankingFeignException.java
@@ -1,0 +1,16 @@
+package org.creditto.creditto_service.global.response.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CoreBankingFeignException extends RuntimeException {
+
+    private final int httpStatus;
+    private final Integer code;
+
+    public CoreBankingFeignException(int httpStatus, Integer code, String message) {
+        super(message);
+        this.httpStatus = httpStatus;
+        this.code = code;
+    }
+}


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #40

## ✅ 작업 내용

- OpenFeign 관련 예외 발생시 예외 상태 코드, 예외 메시지를 그대로 응답하게 하여 Client가 에러 내용을 알 수 있도록 수정
- OpenFeign Config, Exception 설정 및 GloblaHandlerException 등록
- GlobalhandlerException에 누락된 HttpMessageNotReadable 예외 추가

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
